### PR TITLE
Remove unnecessary "is_product_query" call.

### DIFF
--- a/src/BigCommerce/Post_Types/Product/Query.php
+++ b/src/BigCommerce/Post_Types/Product/Query.php
@@ -292,6 +292,26 @@ class Query {
 		return $return;
 	}
 
+	private function is_product_query( \WP_Query $query ) {
+		$post_type = $query->get( 'post_type' );
+		if ( ! empty( $post_type ) ) {
+			if ( is_array( $post_type ) ) {
+				if ( count( $post_type ) > 1 ) {
+					return false;
+				}
+				$post_type = reset( $post_type );
+			}
+
+			return $post_type == Product::NAME;
+		}
+
+		if ( $query->is_tax( [ Brand::NAME, Product_Category::NAME ] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
 	/**
 	 * Product search should match title, BigCommerce ID, or SKU
 	 *


### PR DESCRIPTION
Removing this allows devs to include BC search results (including sku searches) in their site wide search.

No need to check the post type if we're in a site search