### PR TITLE
Fix for invalid date rendering in order summary

### DIFF
--- a/src/BigCommerce/Templates/Order_Summary.php
+++ b/src/BigCommerce/Templates/Order_Summary.php
@@ -90,7 +90,8 @@ class Order_Summary extends Controller {
 	}
 
 	private function format_gmt_date( $date_string ) {
-		return get_date_from_gmt( $date_string, $this->options[ self::DATE_FORMAT ] );
+		$dateTime = new \DateTime( $date_string );
+		return $dateTime->format( $this->options[ self::DATE_FORMAT ] );
 	}
 
 	/**


### PR DESCRIPTION
As reported in: https://github.com/bigcommerce/bigcommerce-for-wordpress/issues/107

For some reason the built-in WP function get_date_from_gmt() can't parse the RFC 2822 date returned from the API. So this switches to using PHP's built in DateTime->format()

*Before merging we should determine why the WP function isn't working correctly. This is here for developers that want a fix in the short term.*

## Before

<img width="1440" alt="screen shot 2018-11-18 at 10 41 14 pm" src="https://user-images.githubusercontent.com/2677921/48686797-8e925d00-eb83-11e8-8df3-d797672abe77.png">

## After

<img width="1440" alt="screen shot 2018-11-18 at 10 41 44 pm" src="https://user-images.githubusercontent.com/2677921/48686807-95b96b00-eb83-11e8-83de-8e7b7cb14e4b.png">
