### PR TITLE
Use amp_post_template_data filter to add AMP scripts in classic mode

### DIFF
--- a/src/BigCommerce/Amp/Amp_Assets.php
+++ b/src/BigCommerce/Amp/Amp_Assets.php
@@ -66,10 +66,11 @@ class Amp_Assets {
 	/**
 	 * Get AMP script handles.
 	 *
-     * This is only relevant in the Classic Mode, as component scripts are automatically in Native/Paired modes.
-     * This is used in an 'amp_post_template_data' filter.
-     *
+	 * This is only relevant in the Classic Mode, as component scripts are automatically in Native/Paired modes.
+	 * This is used in an 'amp_post_template_data' filter.
+	 *
 	 * @see amp_register_default_scripts()
+	 * @return string[] Script handles.
 	 */
 	public function scripts() {
 		$handles = array(

--- a/src/BigCommerce/Amp/Amp_Assets.php
+++ b/src/BigCommerce/Amp/Amp_Assets.php
@@ -64,32 +64,28 @@ class Amp_Assets {
 	}
 
 	/**
-	 * Add AMP scripts.
+	 * Get AMP script handles.
 	 *
+     * This is only relevant in the Classic Mode, as component scripts are automatically in Native/Paired modes.
+     * This is used in an 'amp_post_template_data' filter.
+     *
 	 * @see amp_register_default_scripts()
 	 */
 	public function scripts() {
 		$handles = array(
-			'carousel',
-			'form',
-			'bind',
-			'sidebar',
-			'list',
-			'mustache',
+			'amp-carousel',
+			'amp-form',
+			'amp-bind',
+			'amp-sidebar',
+			'amp-list',
+			'amp-mustache',
 		);
 
 		if ( is_archive() ) {
-			$handles[] = 'lightbox';
+			$handles[] = 'amp-lightbox';
 		}
 
-		foreach ( $handles as $handle ) {
-			if ( ! wp_script_is( 'amp-' . $handle, 'done' ) ) {
-				?>
-				<script async custom-element="amp-<?php echo esc_attr( $handle ); ?>" src="https://cdn.ampproject.org/v0/amp-<?php echo esc_attr( $handle ); ?>-latest.js"></script>
-				<?php
-			}
-		}
-
+		return $handles;
 	}
 
 	/**

--- a/src/BigCommerce/Container/Amp.php
+++ b/src/BigCommerce/Container/Amp.php
@@ -185,6 +185,14 @@ class Amp extends Provider {
 			$container[ self::CUSTOMIZER_STYLES ]->print_css();
 		} ), 10, 0 );
 
+		add_filter( 'amp_post_template_data', $this->create_callback( 'amp_post_template_data', function ( $data ) use ( $container ) {
+			$data['amp_component_scripts'] = array_merge(
+				$data['amp_component_scripts'],
+				array_fill_keys( $container[ self::ASSETS ]->scripts(), true )
+			);
+			return $data;
+		} ), 11, 0 );
+
 		add_action( 'amp_post_template_head', $this->create_callback( 'amp_post_template_head', function () use ( $container ) {
 			$container[ self::ASSETS ]->scripts();
 		} ), 11, 0 );


### PR DESCRIPTION
A user of the AMP plugin reported validation errors when using BigCommerce in the AMP plugin's Classic mode: https://wordpress.org/support/topic/amp-issues-detected/

One of the errors is that this markup is being output by BigCommerce:

```html
<script async custom-element="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
```

It should rather be:

```html
<script type='text/javascript' src='https://cdn.ampproject.org/v0/amp-mustache-0.2.js' async custom-template="amp-mustache"></script>
```

It is incorrectly using `custom-element` when it should be using `custom-template`. Also, instead of `latest` it should be using the current version (`0.2`). Lastly, BigCommerce should not be manually printing the scripts at all, but let the AMP plugin handle it. The AMP plugin automatically will prevent duplicates in this way, and it will output `custom-template` as required:

https://github.com/ampproject/amp-wp/blob/44a94ce43ac95ca853cc6502a113286cb7901a8b/includes/amp-helper-functions.php#L532-L536

AMP scripts should be included in the classic mode's templates via the `amp_post_template_data` filter, as seen in this PR.

Note that I have not tested this PR, though it uses a pattern I've used previously:

* https://gist.github.com/westonruter/a41573b932e24810b09949136b9a8445#file-example-amp-auto-ads-php-L41-L53
* https://wordpress.org/search/amp_post_template_data+intext%3A%22Plugin%3A+AMP%22/#gsc.tab=0&gsc.q=amp_post_template_data%20amp_component_scripts%20intext%3A%22Plugin%3A%20AMP%22&gsc.sort=