### PR TITLE
Github action to submit tagged releases to WP SVN

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,18 @@
+workflow "Deploy" {
+  on = "push"
+  resolves = ["WordPress Plugin Deploy"]
+}
+
+action "tag" {
+  uses = "actions/bin/filter@master"
+  args = "tag"
+}
+
+action "WordPress Plugin Deploy" {
+  uses = "becomevocal/actions-wordpress/dotorg-plugin-deploy@master"
+  needs = ["tag"]
+  secrets = ["SVN_USERNAME", "SVN_PASSWORD"]
+  env = {
+    SLUG = "bigcommerce-for-wordpress"
+  }
+}


### PR DESCRIPTION
#### What?

This is an action that pushes each tagged release here on GitHub to our WordPress SVN repo.

Kudos go to 10up for open sourcing this action! https://github.com/10up/actions-wordpress

All I changed is an exclude for the readme.txt file, which is controlled separately. Don't want to delete that.