### PR TITLE
Change SVN repo slug to our actual slug

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -13,6 +13,6 @@ action "WordPress Plugin Deploy" {
   needs = ["tag"]
   secrets = ["SVN_USERNAME", "SVN_PASSWORD"]
   env = {
-    SLUG = "bigcommerce-for-wordpress"
+    SLUG = "bigcommerce"
   }
 }


### PR DESCRIPTION
#### What?

I used bigcommerce-for-wordpress instead of bigcommerce as our repo slug, which was incorrect. This fixes that.
