### PR TITLE
Add WordPress Logout Link To Account Sub_Nav.

### DIFF
--- a/src/BigCommerce/Accounts/Sub_Nav.php
+++ b/src/BigCommerce/Accounts/Sub_Nav.php
@@ -64,6 +64,11 @@ class Sub_Nav {
 				];
 			}
 		}
+		$links[] = [
+			'url'     => wp_logout_url(),
+			'label'   => _e('Logout', 'bigcommerce'),
+			'current' => false,
+		];
 
 		/**
 		 * Filter the links that show in the account subnav.

--- a/src/BigCommerce/Accounts/Sub_Nav.php
+++ b/src/BigCommerce/Accounts/Sub_Nav.php
@@ -66,7 +66,7 @@ class Sub_Nav {
 		}
 		$links[] = [
 			'url'     => wp_logout_url(),
-			'label'   => _e('Logout', 'bigcommerce'),
+			'label'   => __('Logout', 'bigcommerce'),
 			'current' => false,
 		];
 


### PR DESCRIPTION
#### What?

* Adds the `wp_logout_url()` as a link on the end of the Account Sub_Nav.
* Includes `_e('Logout', 'bigcommerce')` as the label so it can be translated
* Hard codes `current` to `false` since logout isn't actually a page people visit and it will redirect back to the home page.