### PR TITLE
Updated SVN plugin deploy action to latest branch

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -9,9 +9,13 @@ action "tag" {
 }
 
 action "WordPress Plugin Deploy" {
-  uses = "becomevocal/actions-wordpress/dotorg-plugin-deploy@master"
+  uses = "10up/actions-wordpress/dotorg-plugin-deploy@master"
   needs = ["tag"]
-  secrets = ["SVN_USERNAME", "SVN_PASSWORD"]
+  secrets = [
+    "SVN_USERNAME",
+    "SVN_PASSWORD",
+    "GITHUB_TOKEN",
+  ]
   env = {
     SLUG = "bigcommerce"
   }


### PR DESCRIPTION
#### What?

Update to use 10up's latest version of the SVN plugin deploy action, as the one we were using doesn't work and this might help : )