### PR TITLE
Adding wc_get_cart_url() compatibility function

### DIFF
--- a/src/BigCommerce/Compatibility/woocommerce-functions.php
+++ b/src/BigCommerce/Compatibility/woocommerce-functions.php
@@ -39,4 +39,9 @@ if ( ! function_exists( 'woocommerce_mini_cart' ) ) {
 	function woocommerce_mini_cart() {
 		return;
 	}
+
+if ( ! function_exists( 'wc_get_cart_url' ) ) {
+	function wc_get_cart_url() {
+		return;
+	}
 }


### PR DESCRIPTION
Without this function, some themes (like norebro) give a fatal error.