### PR TITLE
Move to new GitHub WP deploy action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,9 +10,8 @@ jobs:
       with:
         args: tag
     - name: WordPress Plugin Deploy
-      uses: 10up/actions-wordpress/dotorg-plugin-deploy@master
+      uses: 10up/action-wordpress-plugin-deploy@master
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SLUG: bigcommerce
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
#### What?

The 10up WP deploy action stopped working so I'm updating to the latest version.
