### PR TITLE
Move deploy action from bin to release filter

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,17 +1,16 @@
-on: push
-name: Deploy
+on: 
+  release:
+    types: [published]
+name: Deploy to WordPress.org
 jobs:
   tag:
+    name: New Release
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: tag
-      uses: actions/bin/filter@master
-      with:
-        args: tag
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@master
       env:
-        SLUG: bigcommerce
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: bigcommerce


### PR DESCRIPTION
#### What?

GitHub removed their actions/bin/filter repo in favor of better built in actions filtering: https://help.github.com/en/articles/events-that-trigger-workflows

This updates to that format as the removal of the repo broke the action.