### PR TITLE
Allowed HTML format to import category description

### DIFF
--- a/src/BigCommerce/Import/Importers/Terms/Term_Saver.php
+++ b/src/BigCommerce/Import/Importers/Terms/Term_Saver.php
@@ -102,7 +102,7 @@ abstract class Term_Saver implements Import_Strategy {
 		// we need to make sure we're getting the same result here
 		return [
 			'slug'        => $this->term_slug( $bc_term ),
-			'description' => wp_filter_kses( $this->sanitize_string( $bc_term['description'] ) ),
+			'description' => $this->sanitize_string( $bc_term['description'] ),
 			'parent'      => $this->determine_parent_term_id( $bc_term ),
 		];
 	}


### PR DESCRIPTION
For allowing HTML format when we synchronize category description from big commerce store to our WordPress website.
