### PR TITLE
Change default template for gift certificates

### DIFF
--- a/src/BigCommerce/Forms/Purchase_Gift_Certificate_Handler.php
+++ b/src/BigCommerce/Forms/Purchase_Gift_Certificate_Handler.php
@@ -170,7 +170,7 @@ class Purchase_Gift_Certificate_Handler implements Form_Handler {
 			__( '%s Gift Certificate', 'bigcommerce' ),
 			apply_filters( 'bigcommerce/currency/format', sprintf( '¤%0.2f', $amount ), $amount )
 		);
-		$theme  = apply_filters( 'bigcommerce/gift_certificates/theme', 'general' );
+		$theme  = apply_filters( 'bigcommerce/gift_certificates/theme', 'General.html' );
 		$data   = [
 			'name'      => $name,
 			'theme'     => $theme,


### PR DESCRIPTION
#### What?

The big commerce cart api appears to expect a .html appended to the end of the Gift certificate template name.   This was tested on a production store, but the dev sandbox store with updated API may differ.  

Compare this entry generated via the WP Plugin cart:
```
     {
                    "id": "bff91f42-5da0-4911-af73-6ed65e953015",
                    "name": "$1.00 Gift Certificate",
                    "theme": "General",
                    "amount": 2,
                    "quantity": 1,
                    "taxable": false,
                    "sender": {
                        "name": "Tim Mulry",
                        "email": "test1@bigcommerce.com"
                    },
                    "recipient": {
                        "name": "Tim",
                        "email": "testwp1@bigcommerce.com"
                    },
                    "message": ""
                }
```
To a similar entry generated directly via the BC store UI:

            ```
    {
                    "id": "530571fb-f7fa-4f3c-b4f2-08dc5c861ea0",
                    "name": "$1.00 Gift Certificate",
                    "theme": "General.html",
                    "amount": 1,
                    "quantity": 1,
                    "taxable": false,
                    "sender": {
                        "name": "Tim Mulry",
                        "email": "test1@bigcommerce.com"
                    },
                    "recipient": {
                        "name": "Tim",
                        "email": "testwp1@bigcommerce.com"
                    },
                    "message": ""
                }
```
#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Issue 197](https://github.com/bigcommerce/bigcommerce-for-wordpress/issues/197)
