### PR TITLE
Add 'load_plugin_textdomain', so translation plugins have the ability…

### DIFF
--- a/bigcommerce.php
+++ b/bigcommerce.php
@@ -64,3 +64,13 @@ function bigcommerce_get_env( $key ) {
 	return $value;
 }
 
+/**
+ * Load plugin textdomain.
+ *
+ * @since 1.0.0
+ */
+function bigcommerce_textdomain() {
+	load_plugin_textdomain( 'bigcommerce', false, basename( dirname( __FILE__ ) ) . '/languages' );
+}
+
+add_action( 'plugins_loaded', 'bigcommerce_textdomain' );


### PR DESCRIPTION
… to read the strings with the 'bigcommerce' textdomain

#### What?
As a non-native English speaker I use tools like Loco Translate to translate English strings (in this case to Dutch). Your plugin did not implement "load_plugin_textdomain", which is a necessity when building a WordPress plugin.

Added this little snippet and made it work.

Not sure what you guys want to do with translations, but it would be nice if a .pot file could be added?

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Codex](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/)
- [Translations not showing](https://localise.biz/wordpress/plugin/faqs/not-showing)
