### PR TITLE
Add filter to Cart_Mapper class `map()` method return value

### DIFF
--- a/src/BigCommerce/Cart/Cart_Mapper.php
+++ b/src/BigCommerce/Cart/Cart_Mapper.php
@@ -83,7 +83,7 @@ class Cart_Mapper {
 			'formatted' => $this->format_currency( $subtotal ),
 		];
 
-		return $cart;
+		return apply_filters('bigcommerce/cart_mapper/map', $cart);
 	}
 
 	private function cart_items() {


### PR DESCRIPTION
#### What?

This plugin generously provides filters and hooks for most data, however, when Javascript calls are made to the WP REST endpoints many of these filters are bypassed.   For example, when filtering a product's `calculated_price`, the filtered data is rendered as expected on the product pages.  However, if a user updates the quantity (or adds/removes other cart items) within the cart, the pricing on the page is pulled from BigCommerce and the filters are never fired.  The result is a poor user experience and incorrect pricing being displayed.  Adding this filter will allow developers to filter pricing in the cart despite the origin of the request, Ajax or otherwise.