### PR TITLE
Create CODEOWNERS and add dev-docs team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+CHANGELOG.md @bigcommerce/dev-docs


### PR DESCRIPTION
#### What?

Add a [CODEOWNERS file](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners) and make sure @bigcommerce/dev-docs gets pinged on any changes to CHANGELOG.md (which should mostly be for new versions)

