### PR TITLE
Fix "ga is not defined" bug

### DIFF
--- a/assets/js/src/public/analytics/segment.js
+++ b/assets/js/src/public/analytics/segment.js
@@ -48,8 +48,10 @@ const handleClickTracker = (e) => {
 
 const gaCrossDomainInit = async () => {
 	await analytics.ready(() => {
-		ga('require', 'linker');
-		ga('linker:autoLink', [STORE_DOMAIN]);
+		if (typeof ga === 'function') {
+			ga('require', 'linker');
+			ga('linker:autoLink', [STORE_DOMAIN]);
+		}
 	});
 };
 


### PR DESCRIPTION
#### What?

On a fresh install, or GA is not a tag on the website, we get a "ga is not defined" javascript error
This should check if GA exists first 

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

#### Screenshots 

scripts.min.js?ver=4.8.0-5.54.02.05.2021:10 Uncaught ReferenceError: ga is not defined
    at scripts.min.js?ver=4.8.0-5.54.02.05.2021:10
    at i.run (analytics.min.js:4)
    at o (analytics.min.js:4)
