### PR TITLE
Adds support for fetching BigCommerce Products by SKU.  Including via shortcode

### DIFF
--- a/src/BigCommerce/Shortcodes/Product_Components.php
+++ b/src/BigCommerce/Shortcodes/Product_Components.php
@@ -26,10 +26,11 @@ class Product_Components implements Shortcode {
 	 */
 	public static function default_attributes() {
 		return [
-			'id'      => 0, // BigCommerce product ID
-			'post_id' => 0, // WordPress post ID
+			'id'      => 0,  // BigCommerce product ID
+			'sku'     => '', // BigCommerce product SKU
+			'post_id' => 0,  // WordPress post ID
 			'type'    => '', // Type of product component
-			'preview' => 0, // internal use: set to 1 to remove interactive elements
+			'preview' => 0,  // internal use: set to 1 to remove interactive elements
 		];
 	}
 
@@ -41,6 +42,14 @@ class Product_Components implements Shortcode {
 			try {
 				$product = Product::by_product_id( absint( $attr['id'] ) );
 			} catch ( \Exception $e ) {
+				return $this->product_not_found();
+			}
+		} else if ( ! empty( $attr['sku'] ) ) {
+			// The $attr['sku'] is the BC product SKU
+			try {
+				$product = Product::by_product_sku($attr['sku']);
+			}
+			catch ( \Exception $e ) {
 				return $this->product_not_found();
 			}
 		} else {


### PR DESCRIPTION
Adds support for fetching BigCommerce Products by SKU.  
- Adds static methods `by_product_sku` and `query` to the `BigCommerce\Post_Types\Product` class 
- Add default attribute of `sku` to the `Product_Components` class implementing the `bc-component` shortcode

#### Documentation

Historically, one would only be able to fetch a product with a BigCommerce Product ID
E.g. `$product = \BigCommerce\Post_Types\Product\Product::by_product_id( $product_id );`

This pull request adds the ability to fetch of a product in a very similar fashion by BigCommerce Product SKU
E.g. `$product = \BigCommerce\Post_Types\Product\Product::by_product_sku( $product_sku );`

Additionally, the `bc-component` shortcode attributes have been updated to support fetching by BigCommerce Product SKU as well.
E.g. `echo do_shortcode('[bc-component sku="' . $product_sku . '" type="add_to_cart"]');`
