### PR TITLE
Fix broken set_product_query

### DIFF
--- a/src/BigCommerce/Taxonomies/Product_Category/Query_Filter.php
+++ b/src/BigCommerce/Taxonomies/Product_Category/Query_Filter.php
@@ -129,17 +129,20 @@ class Query_Filter {
 			return;
 		}
 
+		$escaped_ids = implode(', ', array_map( function($n) use ($wpdb) {
+			return $wpdb->prepare('%d', $n);
+		}, $this->group_filtered_terms->get_visible_terms()));
+
 		$sql = "SELECT p.ID
 		        FROM {$wpdb->posts} p
 		        INNER JOIN {$wpdb->term_relationships} r ON r.object_id=p.ID
-		        WHERE p.post_name=%s AND p.post_type=%s AND r.term_taxonomy_id IN (%s)";
+		        WHERE p.post_name=%s AND p.post_type=%s AND r.term_taxonomy_id IN (" . $escaped_ids .")";
 
 		$post_id = $wpdb->get_var(
 			$wpdb->prepare(
 				$sql,
 				$name,
-				Product::NAME,
-				implode( ', ', array_map( 'intval', $this->group_filtered_terms->get_visible_terms() ) )
+				Product::NAME
 			)
 		) ?: - 1;
 


### PR DESCRIPTION
Fix query built for filtering of products based on categories display…ed to a specific user group

#### What?

There is a bug where products could not be displayed to a user that was assigned to a user group, even if they had permissions to access the appropriate categories. The issue was that the query was being wrongly formatted and was never returning an appropriate post ID.

#### Tickets / Documentation

You can see the sql generated previously here:

```
SELECT p.ID
FROM xxxx_posts p
INNER JOIN xxxx_term_relationships r
ON r.object_id=p.ID
WHERE p.post_name='some-post-slug'
AND p.post_type='bigcommerce_product'
AND r.term_taxonomy_id IN ('105, 37, 38, 36, 27, 102, 40, 39, 54, 89, 41, 35, 42, 43, 44, 103, 20, 25, 45, 21, 46')
```

The issue is here: `IN ('105, 37, 38, 36, 27, 102, 40, 39, 54, 89, 41, 35, 42, 43, 44, 103, 20, 25, 45, 21, 46')` This is not a valid "In query, as it is looking at the entire string of post IDs.

The new code in this pull request creates the following query, which produces the expected result.

```
SELECT p.ID
FROM KIkei8_posts p
INNER JOIN KIkei8_term_relationships r
ON r.object_id=p.ID
WHERE p.post_name='wholesale-furniture-tags-set-of-25'
AND p.post_type='bigcommerce_product'
AND r.term_taxonomy_id IN (105, 37, 38, 36, 27, 102, 40, 39, 54, 89, 41, 35, 42, 43, 44, 103, 20, 25, 45, 21, 46)
```
