### PR TITLE
Update wc_get_page_id compatability return type

### DIFF
--- a/src/BigCommerce/Compatibility/woocommerce-functions.php
+++ b/src/BigCommerce/Compatibility/woocommerce-functions.php
@@ -138,6 +138,6 @@ if ( ! function_exists( 'woocommerce_reset_loop' ) ) {
 
 if ( ! function_exists( 'wc_get_page_id' ) ) {
 	function wc_get_page_id() {
-		return '';
+		return -1;
 	}
 }


### PR DESCRIPTION
#### What?

This updates the compatibility version of `wc_get_page_id` to always return an integer to match the behavior of WC core. The current behavior of returning a string could cause issues with themes/plugins that are expecting an integer value.

#### Tickets / Documentation

- [Current definition of wc_get_page_id](https://github.com/woocommerce/woocommerce/blob/9c83a07145ea5c451adc489f21eeaf895825b683/plugins/woocommerce/includes/wc-page-functions.php#L36-L57)
