### PR TITLE
chore(ci): use WP composite deploy

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,13 +7,10 @@ jobs:
     name: New Release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     # See https://github.com/actions/runner/issues/2033
-    - name: Configure Git
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@master
+      uses: 10up/action-wordpress-plugin-deploy@2.2.1
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
#### What?

Use the composite WP action instead of using the container deploy: https://github.com/10up/action-wordpress-plugin-deploy/releases/tag/2.0.0