### PR TITLE
Add: Filter hook for Image Size on Cart Items

### DIFF
--- a/src/BigCommerce/Templates/Cart_Items.php
+++ b/src/BigCommerce/Templates/Cart_Items.php
@@ -18,7 +18,12 @@ class Cart_Items extends Controller {
 	protected function parse_options( array $options ) {
 		$defaults = [
 			self::CART       => [],
-			self::IMAGE_SIZE => Image_Sizes::BC_SMALL,
+			/**
+			 * Filter the image size used for cart item image
+			 *
+			 * @param string $size The image size to use
+			 */
+			self::IMAGE_SIZE => apply_filters( 'bigcommerce/template/cart_items_image/size', Image_Sizes::BC_SMALL ),
 		];
 
 		return wp_parse_args( $options, $defaults );


### PR DESCRIPTION
#### What?
Add a filter hook, namely `bigcommerce/template/cart_items_image/size`, for the IMAGE_SIZE option on the Cart_Items template. 
#### Tickets / Documentation
N/A
#### Screenshots (if appropriate)
N/A