### PR TITLE
chore: bump readme.txt version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bigcommerce, moderntribe, jbrinley, becomevocal, vincentlistrani, 
 Tags: ecommerce, online store, sell online, storefront, retail, online shop, bigcommerce, big commerce, e-commerce, physical products, buy buttons, commerce, shopping cart, checkout, cart, shop, headless commerce, shipping, payments, fulfillment
 Requires at least: 5.2
 Tested up to: 6.3.1
-Stable tag: 5.0.6
+Stable tag: 5.0.7
 Requires PHP: 7.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
#### What?

Adds the new version to the `readme.txt` to show up on [Wordpress.org](https://wordpress.org/plugins/bigcommerce/#description).

#### Tickets / Documentation

n/a

#### Screenshots (if appropriate)

n/a