### PR TITLE
Initial commit to update supported version of WordPress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [5.0.8]
+
+### Changed
+- Update plugin readme `tested up` version
+
 ## [5.0.7]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1919,6 +1919,7 @@
   in fact, reset postdata, so far as Gutenberg 3.2.0 is concerned.
 
 
+[5.0.8]: https://github.com/bigcommerce/bigcommerce-for-wordpress/compare/5.0.7...5.0.8
 [5.0.7]: https://github.com/bigcommerce/bigcommerce-for-wordpress/compare/5.0.6...5.0.7
 [5.0.6]: https://github.com/bigcommerce/bigcommerce-for-wordpress/compare/5.0.5...5.0.6
 [5.0.5]: https://github.com/bigcommerce/bigcommerce-for-wordpress/compare/5.0.4...5.0.5

--- a/bigcommerce.php
+++ b/bigcommerce.php
@@ -3,7 +3,7 @@
 Plugin Name:  BigCommerce for WordPress
 Description:  Scale your ecommerce business with WordPress on the front-end and BigCommerce on the back end. Free up server resources from things like catalog management, processing payments, and managing fulfillment logistics.
 Author:       BigCommerce
-Version:      5.0.7
+Version:      5.0.8
 Author URI:   https://www.bigcommerce.com/wordpress
 Requires PHP: 7.4.0
 Text Domain:  bigcommerce

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: bigcommerce, moderntribe, jbrinley, becomevocal, vincentlistrani, jbirthler, kdiplas, iliabaum, joshliston, nickioa, fernando22, mr_speer, geoffgraham, yuenvision, xwp, karenpwhite, mlkilderkin
 Tags: ecommerce, online store, sell online, storefront, retail, online shop, bigcommerce, big commerce, e-commerce, physical products, buy buttons, commerce, shopping cart, checkout, cart, shop, headless commerce, shipping, payments, fulfillment
 Requires at least: 5.2
-Tested up to: 6.3.1
-Stable tag: 5.0.7
+Tested up to: 6.6
+Stable tag: 5.0.8
 Requires PHP: 7.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bigcommerce, moderntribe, jbrinley, becomevocal, vincentlistrani, 
 Tags: ecommerce, online store, sell online, storefront, retail, online shop, bigcommerce, big commerce, e-commerce, physical products, buy buttons, commerce, shopping cart, checkout, cart, shop, headless commerce, shipping, payments, fulfillment
 Requires at least: 5.2
 Tested up to: 6.6
-Stable tag: 5.0.8
+Stable tag: 5.0.7
 Requires PHP: 7.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bigcommerce, moderntribe, jbrinley, becomevocal, vincentlistrani, 
 Tags: ecommerce, online store, sell online, storefront, retail, online shop, bigcommerce, big commerce, e-commerce, physical products, buy buttons, commerce, shopping cart, checkout, cart, shop, headless commerce, shipping, payments, fulfillment
 Requires at least: 5.2
 Tested up to: 6.6
-Stable tag: 5.0.7
+Stable tag: 5.0.8
 Requires PHP: 7.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/BigCommerce/Plugin.php
+++ b/src/BigCommerce/Plugin.php
@@ -4,7 +4,7 @@
 namespace BigCommerce;
 
 class Plugin {
-	const VERSION = '5.0.7';
+	const VERSION = '5.0.8';
 
 	protected static $_instance;
 


### PR DESCRIPTION
#### What?

This bumps the version of WordPress to look to solve the readme file piece of #458.

### Additional

This will still need testing beyond this version and a new plugin version released once this happens.