### PR TITLE
Update README.md to include support for PHP Function tmpfile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ As with any WordPress plugin, upload the plugin ZIP file to the
 * WordPress: 5.8+
 * SSL
 * The PHP intl extension will enable better currency formatting
+* Support for tmpfile() function in php.ini
 
 ### Assets build
 
@@ -85,6 +86,10 @@ canonical using the dropdowns in this settings section.
 
 The "Support Email" field will be used to give customers an address to contact you
 with questions about orders.
+
+**Updating Account Information:** In order to update account information, including a users
+password and have it syncronize to BigCommerce you will need to ensure you have global 
+PHP tmpfile() function enabled. Please not this can be disabled on some hosting providers.
 
 ### Theme Customizer
 


### PR DESCRIPTION
I updated the requirements to include the PHP global function tmpfile() and also added a point in the Accounts and Registration section to explain this requirement for updating account and password information and having it successfully sync to BigCommerce.

#### What?

It was discovered after resolving this critical error that the php tmpfile function is required for the BigCommerce plugin to successfully allow updating of account information to be successfully synced to BigCommerce from WordPress. The provided documentation explain all the errors and resolution.

#### Tickets / Documentation

- [Issue on Github](https://github.com/bigcommerce/bigcommerce-for-wordpress/issues/462)
- [Issue on WordPress Forums](https://wordpress.org/support/topic/customers-cannot-login-to-their-user-accounts-on-wp/)
- [KB article on Convesio](https://convesio.com/knowledgebase/article/resolving-critical-errors-updating-users-in-wordpress-and-syncing-to-bigcommerce/)


#### Screenshots (if appropriate)

No Images for this issue.

