### PR TITLE
Enhance channel name handling by adding sanitization methods

### DIFF
--- a/src/BigCommerce/Settings/Sections/Channel_Select.php
+++ b/src/BigCommerce/Settings/Sections/Channel_Select.php
@@ -31,9 +31,7 @@ class Channel_Select extends Settings_Section {
 		register_setting(
 			Connect_Channel_Screen::NAME,
 			self::NEW_NAME,
-			[
-				'sanitize_callback' => [ $this, 'sanitize_channel_name' ],
-			]
+			[ 'sanitize_callback' => [ $this, 'sanitize_channel_name' ] ]
 		);
 
 		add_settings_field(
@@ -53,7 +51,7 @@ class Channel_Select extends Settings_Section {
 			[
 				'type'    => 'text',
 				'option'  => self::NEW_NAME,
-				'default' => $this->sanitize_channel_name(parse_url( home_url(), PHP_URL_HOST )),
+				'default' => $this->sanitize_channel_name( parse_url( home_url(), PHP_URL_HOST ) ),
 				'class'   => 'bc-create-channel-wrapper',
 			]
 		);
@@ -96,13 +94,13 @@ class Channel_Select extends Settings_Section {
 	 * @param string $name The channel name to sanitize
 	 * @return string The sanitized channel name
 	 */
-	public function sanitize_channel_name($name) {
-		if (empty($name)) {
+	public function sanitize_channel_name( $name ) {
+		if ( empty( $name ) ) {
 			$name = parse_url( home_url(), PHP_URL_HOST );
 		}
-		$name = str_replace('.', '-', $name);
-		$name = preg_replace('/[^A-Za-z0-9\-_\s]/', '', $name);
-		return trim($name);
+		$name = str_replace( '.', '-', $name );
+		$name = preg_replace( '/[^A-Za-z0-9\-_\s]/', '', $name );
+		return trim( $name );
 	}
 
 	/**

--- a/src/BigCommerce/Settings/Sections/Channel_Select.php
+++ b/src/BigCommerce/Settings/Sections/Channel_Select.php
@@ -99,7 +99,6 @@ class Channel_Select extends Settings_Section {
 			$name = parse_url( home_url(), PHP_URL_HOST );
 		}
 		$name = str_replace( '.', '-', $name );
-		$name = preg_replace( '/[^A-Za-z0-9\-_\s]/', '', $name );
 		return trim( $name );
 	}
 

--- a/src/BigCommerce/Settings/Sections/Channel_Select.php
+++ b/src/BigCommerce/Settings/Sections/Channel_Select.php
@@ -31,7 +31,9 @@ class Channel_Select extends Settings_Section {
 		register_setting(
 			Connect_Channel_Screen::NAME,
 			self::NEW_NAME,
-			'__return_false'
+			[
+				'sanitize_callback' => [ $this, 'sanitize_channel_name' ],
+			]
 		);
 
 		add_settings_field(
@@ -51,7 +53,7 @@ class Channel_Select extends Settings_Section {
 			[
 				'type'    => 'text',
 				'option'  => self::NEW_NAME,
-				'default' => parse_url( home_url(), PHP_URL_HOST ),
+				'default' => $this->sanitize_channel_name(parse_url( home_url(), PHP_URL_HOST )),
 				'class'   => 'bc-create-channel-wrapper',
 			]
 		);
@@ -86,5 +88,33 @@ class Channel_Select extends Settings_Section {
 		}, $terms );
 
 		return $list;
+	}
+
+	/**
+	 * Sanitize the channel name before saving or using
+	 *
+	 * @param string $name The channel name to sanitize
+	 * @return string The sanitized channel name
+	 */
+	public function sanitize_channel_name($name) {
+		if (empty($name)) {
+			$name = parse_url( home_url(), PHP_URL_HOST );
+		}
+		$name = str_replace('.', '-', $name);
+		$name = preg_replace('/[^A-Za-z0-9\-_\s]/', '', $name);
+		return trim($name);
+	}
+
+	/**
+	 * Override parent render_field to ensure channel name is sanitized
+	 */
+	public function render_field( $args ) {
+		if ($args['option'] === self::NEW_NAME) {
+			$args['default'] = $this->sanitize_channel_name($args['default']);
+			if (isset($_POST[self::NEW_NAME])) {
+				$_POST[self::NEW_NAME] = $this->sanitize_channel_name($_POST[self::NEW_NAME]);
+			}
+		}
+		parent::render_field($args);
 	}
 }


### PR DESCRIPTION
#### What?

- Implemented `sanitize_channel_name` method to sanitize channel names before saving or using them.
- Updated the settings registration to include a sanitize callback.
- Modified the default value for the channel name to use the sanitized version of the home URL.
- Overrode `render_field` method to ensure the channel name is sanitized during rendering.

These changes ensure that the default channel name does not include periods which leads to an error creating the channel

Fixes #480 

#### Screenshots (if appropriate)

https://www.loom.com/share/c1876a4d63fd4dd9a0e57e0ce853a204?sid=0dd69a94-b19f-478c-825f-55d8f55331c1